### PR TITLE
Rework Log.e()

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,8 +355,7 @@ class MainActivity : ComponentActivity() {
         try {
             this.bindService(intent, serviceConnection, Context.BIND_AUTO_CREATE)
         } catch (e: Exception) {
-            Log.e(TAG, "Unable to bind HelloWorldService");
-            e.printStackTrace()
+            Log.e(TAG, "Unable to bind HelloWorldService", e)
         }
     }
 

--- a/app/HelloWorldApp/app/src/main/java/com/example/helloworldapp/MainActivity.kt
+++ b/app/HelloWorldApp/app/src/main/java/com/example/helloworldapp/MainActivity.kt
@@ -57,8 +57,7 @@ class MainActivity : ComponentActivity() {
         try {
             this.bindService(intent, serviceConnection, Context.BIND_AUTO_CREATE)
         } catch (e: Exception) {
-            Log.e(TAG, "Unable to bind HelloWorldService");
-            e.printStackTrace()
+            Log.e(TAG, "Unable to bind HelloWorldService", e)
         }
     }
 


### PR DESCRIPTION
The function Log.e() has a third argument for the exception. So no need for e.printStackTrace(). It's already included in Log.e and makes the code shorter.

This patch was not compile or runtime tested :-/